### PR TITLE
Improvements from use

### DIFF
--- a/.changeset/auto-write-provenance-repository.md
+++ b/.changeset/auto-write-provenance-repository.md
@@ -1,0 +1,9 @@
+---
+'setup-trusted-publishing': minor
+---
+
+Automatically write `publishConfig.provenance: true` and `repository` URL to the source `package.json` during setup.
+
+`provenance: true` enables npm provenance attestation on future publishes. The `repository` URL is detected from the git remote (`origin`) and normalised to a plain HTTPS string — SSH remotes and `git+https://` prefixes are converted automatically.
+
+Neither field is written if already present. Both are written in a single file update to avoid multiple reads/writes.

--- a/.changeset/force-bypasses-existence-check.md
+++ b/.changeset/force-bypasses-existence-check.md
@@ -1,0 +1,7 @@
+---
+'setup-trusted-publishing': minor
+---
+
+`--force` now also bypasses the "already published — nothing to do" early exit.
+
+Previously `--force` only suppressed access-conflict errors. It now additionally re-runs the full setup flow even when the package already exists on the registry, which is useful for re-publishing the stub or testing the setup against an existing package.

--- a/.changeset/hints-for-no-publish.md
+++ b/.changeset/hints-for-no-publish.md
@@ -1,0 +1,7 @@
+---
+'setup-trusted-publishing': patch
+---
+
+Post-publish hints are now shown when using `--no-publish`.
+
+The missing-metadata hint and the repository URL case-sensitivity reminder were previously only shown after a live publish. They now also appear after `--no-publish` packs the tarball, since the same follow-up steps apply.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Publish a 0.0.0 stub to npm so OIDC trusted publishing can be configured",
   "type": "module",
   "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f",
+  "repository": "https://github.com/ThisIsMissEm/setup-trusted-publishing",
   "engines": {
     "node": ">=24.15.0"
   },
@@ -48,6 +49,7 @@
     "typescript": "^6"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,11 @@
 import { parseArgs } from 'node:util'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
 import { promises as fs } from 'node:fs'
 import { mkdtempDisposable } from 'node:fs/promises'
 import validate from 'validate-npm-package-name'
-import { readPackage, writePackageAccess } from './packument.ts'
+import { readPackage, writePackageFields } from './packument.ts'
 import { resolveAccess, AccessConflictError } from './access.ts'
 import { buildStubManifest, writeStubDir, verifyStubDir } from './stub.ts'
 import { detectPackageManager, packageExists, packStub, runPublish } from './registry.ts'
@@ -31,6 +32,53 @@ export function formatSuccessUrl(name: string, effectiveRegistry: string): strin
     return `Published ${name}@0.0.0 → https://www.npmjs.com/package/${urlSafeName}`
   }
   return `Published ${name}@0.0.0 to ${effectiveRegistry}`
+}
+
+/** Exported for testing. */
+export function detectRepositoryUrl(cwd: string): string | null {
+  let remote: string
+  try {
+    remote = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd, encoding: 'utf8' }).trim()
+  } catch {
+    return null
+  }
+
+  // SSH → HTTPS: git@github.com:user/repo.git → https://github.com/user/repo
+  remote = remote.replace(/^git@([^:]+):(.+)$/, 'https://$1/$2')
+  // Strip git+https:// prefix
+  remote = remote.replace(/^git\+/, '')
+  // Strip trailing .git
+  remote = remote.replace(/\.git$/, '')
+
+  try {
+    const url = new URL(remote)
+    return `${url.protocol}//${url.host}${url.pathname}`
+  } catch {
+    return null
+  }
+}
+
+function logPostPublishHints(
+  log: (msg: string) => void,
+  pkg: import('./packument.ts').PackageJson,
+  detectedRepository: string | null
+): void {
+  log('')
+
+  const missingMeta = (['repository', 'homepage', 'bugs'] as const).filter((f) => {
+    if (f === 'repository' && detectedRepository) return false
+    return !pkg[f]
+  })
+  if (missingMeta.length > 0) {
+    log(
+      `hint: add ${missingMeta.map((f) => `"${f}"`).join(', ')} to package.json — ` +
+        `npm uses these for package discovery`
+    )
+  }
+
+  log(
+    `hint: the repository URL in package.json is case-sensitive for provenance and trusted publishing,\n      verify it exactly matches your GitHub (or other host) URL`
+  )
 }
 
 export default async function main(opts: MainOptions = {}): Promise<number> {
@@ -71,7 +119,7 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
       --no-publish     Write source package.json, pack the stub, copy tarball to
                        --cwd — but do not publish (for unsupported package managers)
       --access <mode>  'public' or 'restricted'
-  -f, --force          Bypass access conflict errors
+  -f, --force          Bypass access conflict errors and re-run even if package exists
       --registry <url> Registry to check and publish to
   -C, --cwd <path>     Source package directory (default: cwd)
   -h, --help`)
@@ -90,10 +138,7 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
     err('--dry-run and --no-publish cannot be used together')
     return 2
   }
-  if (dryRun && force) {
-    err('--dry-run and --force cannot be used together')
-    return 2
-  }
+
   if (flagAccess !== undefined && flagAccess !== 'public' && flagAccess !== 'restricted') {
     err(`Invalid --access value: "${flagAccess}". Must be "public" or "restricted".`)
     return 2
@@ -150,7 +195,7 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
     return 1
   }
 
-  if (exists) {
+  if (exists && !force) {
     log(`${name} is already published — nothing to do.`)
     return 0
   }
@@ -188,21 +233,41 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
     throw e
   }
 
-  // ── Step 7: Write publishConfig.access to source (unless dry-run) ──────
+  // ── Step 7: Write publishConfig updates + repository to source (unless dry-run) ──
 
-  if (accessResolution.changed && !dryRun) {
-    await writePackageAccess(cwd, pkgResult, accessResolution.value)
+  const needsProvenance = !pkgResult.parsed.publishConfig?.provenance
+
+  let detectedRepository: string | null = null
+  if (!pkgResult.parsed.repository) {
+    detectedRepository = detectRepositoryUrl(cwd)
+  }
+
+  if (!dryRun) {
+    const pkgUpdates: Parameters<typeof writePackageFields>[2] = {}
+    if (accessResolution.changed || needsProvenance) {
+      const publishConfigUpdates: Record<string, unknown> = {}
+      if (accessResolution.changed) publishConfigUpdates['access'] = accessResolution.value
+      if (needsProvenance) publishConfigUpdates['provenance'] = true
+      pkgUpdates.publishConfig = publishConfigUpdates
+    }
+    if (detectedRepository) pkgUpdates.repository = detectedRepository
+    if (Object.keys(pkgUpdates).length > 0) {
+      await writePackageFields(cwd, pkgResult, pkgUpdates)
+    }
   }
 
   // ── Step 8: Build stub manifest ─────────────────────────────────────────
 
-  // Use the updated access value so buildStubManifest sees the resolved publishConfig
-  const updatedPkg = accessResolution.changed
-    ? {
-        ...pkgResult.parsed,
-        publishConfig: { ...pkgResult.parsed.publishConfig, access: accessResolution.value },
-      }
-    : pkgResult.parsed
+  // Use the updated values so buildStubManifest sees the resolved publishConfig
+  const updatedPkg = {
+    ...pkgResult.parsed,
+    publishConfig: {
+      ...pkgResult.parsed.publishConfig,
+      ...(accessResolution.changed ? { access: accessResolution.value } : {}),
+      ...(needsProvenance ? { provenance: true } : {}),
+    },
+    ...(detectedRepository ? { repository: detectedRepository } : {}),
+  }
 
   const stubManifest = buildStubManifest(updatedPkg, accessResolution.value)
 
@@ -242,9 +307,10 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
   if (noPublish) {
     const dest = join(cwd, tarballName)
     await fs.copyFile(tarballPath, dest)
-    log(`Stub packed to ./${tarballName}`)
+    log(`Stub packed to ./${tarballName}\n`)
     log(`Run your publish command to complete the initial publish, e.g.:`)
     log(`  yarn npm publish ./${tarballName}`)
+    logPostPublishHints(log, pkgResult.parsed, detectedRepository)
     return 0
   }
 
@@ -263,6 +329,7 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
   // Step 16: Success output
   const effectiveRegistry = registry ?? env['NPM_CONFIG_REGISTRY'] ?? 'https://registry.npmjs.org/'
   log(formatSuccessUrl(name, effectiveRegistry))
+  logPostPublishHints(log, pkgResult.parsed, detectedRepository)
 
   return 0
   // Step 17: temp dir auto-cleans via await using

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,13 +1,13 @@
 import { createRequire } from 'node:module'
 // CJS interop for CommonJS modules that don't support ESM imports natively
-const require = createRequire(import.meta.url)
+const cjsRequire = createRequire(import.meta.url)
 
-export const packPackage = require('libnpmpack') as (
+export const packPackage = cjsRequire('libnpmpack') as (
   spec: string,
   opts?: Record<string, unknown>
 ) => Promise<Buffer>
 
-export const registryFetch = require('npm-registry-fetch') as (
+export const registryFetch = cjsRequire('npm-registry-fetch') as (
   uri: string,
   opts?: Record<string, unknown>
 ) => Promise<{ body: { resume(): void } }>

--- a/src/packument.ts
+++ b/src/packument.ts
@@ -40,19 +40,51 @@ export async function readPackage(cwd: string): Promise<ReadPackageResult> {
   return { raw, parsed, indent, hasTrailingNewline }
 }
 
-export async function writePackageAccess(
+export interface PackageUpdates {
+  publishConfig?: Partial<NonNullable<PackageJson['publishConfig']>>
+  repository?: string
+}
+
+export async function writePackageFields(
   cwd: string,
   result: ReadPackageResult,
-  access: 'public' | 'restricted'
+  updates: PackageUpdates
 ): Promise<void> {
   const { parsed, indent, hasTrailingNewline } = result
 
-  const updated: PackageJson = {
-    ...parsed,
-    publishConfig: {
-      ...parsed.publishConfig,
-      access,
-    },
+  const updated: PackageJson = { ...parsed }
+
+  if (updates.publishConfig) {
+    updated.publishConfig = { ...parsed.publishConfig, ...updates.publishConfig }
+  }
+
+  if (updates.repository !== undefined && !parsed.repository) {
+    // Reconstruct to position repository before license (standard package.json field order)
+    const ANCHOR_KEYS = new Set([
+      'license',
+      'files',
+      'scripts',
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+      'engines',
+      'publishConfig',
+    ])
+    const reordered: PackageJson = {}
+    let placed = false
+    for (const [k, v] of Object.entries(updated) as [string, unknown][]) {
+      if (!placed && ANCHOR_KEYS.has(k)) {
+        reordered['repository'] = updates.repository
+        placed = true
+      }
+      reordered[k] = v
+    }
+    if (!placed) reordered['repository'] = updates.repository
+    Object.keys(updated).forEach((k) => delete updated[k])
+    Object.assign(updated, reordered)
+  } else if (updates.repository !== undefined) {
+    updated.repository = updates.repository
   }
 
   let content = JSON.stringify(updated, null, indent)

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -31,12 +31,15 @@ export function buildStubManifest(
     throw new Error('package.json is missing the required "name" field')
   }
 
+  // provenance is a publish-time flag that errors with tarball publishing — strip it from the stub
+  const { provenance, ...publishConfigBase } = { ...source.publishConfig }
+
   const manifest: StubManifest = {
     name: source.name,
     version: '0.0.0',
     main: 'index.js',
     description: source.description ?? 'Stub package for npm trusted publishing setup',
-    publishConfig: { ...source.publishConfig, access: resolvedAccess },
+    publishConfig: { ...publishConfigBase, access: resolvedAccess },
   }
 
   for (const field of OPTIONAL_FIELDS) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createMockRegistry } from './helpers/mock_registry.ts'
 import { createMockPM } from './helpers/mock_pm.ts'
-import main, { formatSuccessUrl } from '../src/cli.ts'
+import main, { formatSuccessUrl, detectRepositoryUrl } from '../src/cli.ts'
 
 // Helper: run the CLI with full isolation
 async function runCLI(opts: {
@@ -158,10 +158,16 @@ test('--dry-run + --no-publish together → exit 2', async () => {
   }
 })
 
-test('--force + --dry-run together → exit 2', async () => {
-  const ctx = await runCLI({ argv: ['--force', '--dry-run'] })
+test('--force bypasses already-published exit', async () => {
+  const ctx = await runCLI({
+    pkgJson: { name: 'test-pkg', version: '1.0.0' },
+    knownPackages: ['test-pkg'],
+    argv: ['--force'],
+  })
   try {
-    assert.strictEqual(ctx.code, 2)
+    assert.ok(!ctx.out.some((l) => l.includes('nothing to do')))
+    const calls = await ctx.pm.getCalls()
+    assert.ok(calls.length > 0, 'publish should have been called')
   } finally {
     await cleanup(ctx)
   }
@@ -406,5 +412,52 @@ describe('formatSuccessUrl', () => {
     const url = formatSuccessUrl('my-pkg', 'https://my-registry.example.com/')
     assert.ok(url.includes('my-registry.example.com'))
     assert.ok(!url.includes('npmjs.com'))
+  })
+})
+
+// ── detectRepositoryUrl unit tests ────────────────────────────────────────
+
+describe('detectRepositoryUrl', () => {
+  let dir: string
+
+  test('returns null when not in a git repo', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'no-git-'))
+    const url = detectRepositoryUrl(dir)
+    assert.strictEqual(url, null)
+    await rm(dir, { recursive: true })
+  })
+
+  test('normalises HTTPS remote — strips .git suffix', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'test-git-'))
+    const { execFileSync } = await import('node:child_process')
+    execFileSync('git', ['init'], { cwd: dir })
+    execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/owner/repo.git'], {
+      cwd: dir,
+    })
+    const url = detectRepositoryUrl(dir)
+    assert.strictEqual(url, 'https://github.com/owner/repo')
+    await rm(dir, { recursive: true })
+  })
+
+  test('normalises SSH remote to HTTPS', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'test-git-'))
+    const { execFileSync } = await import('node:child_process')
+    execFileSync('git', ['init'], { cwd: dir })
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:owner/repo.git'], { cwd: dir })
+    const url = detectRepositoryUrl(dir)
+    assert.strictEqual(url, 'https://github.com/owner/repo')
+    await rm(dir, { recursive: true })
+  })
+
+  test('strips git+https:// prefix', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'test-git-'))
+    const { execFileSync } = await import('node:child_process')
+    execFileSync('git', ['init'], { cwd: dir })
+    execFileSync('git', ['remote', 'add', 'origin', 'git+https://github.com/owner/repo.git'], {
+      cwd: dir,
+    })
+    const url = detectRepositoryUrl(dir)
+    assert.strictEqual(url, 'https://github.com/owner/repo')
+    await rm(dir, { recursive: true })
   })
 })

--- a/tests/packument.test.ts
+++ b/tests/packument.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { readPackage, writePackageAccess } from '../src/packument.ts'
+import { readPackage, writePackageFields } from '../src/packument.ts'
 
 describe('readPackage', () => {
   let dir: string
@@ -47,7 +47,7 @@ describe('readPackage', () => {
   })
 })
 
-describe('writePackageAccess', () => {
+describe('writePackageFields', () => {
   let dir: string
   before(async () => {
     dir = await mkdtemp(join(tmpdir(), 'test-pkg-'))
@@ -60,19 +60,18 @@ describe('writePackageAccess', () => {
     const original = '{\n  "name": "foo",\n  "version": "1.0.0"\n}\n'
     await writeFile(join(dir, 'package.json'), original)
     const r = await readPackage(dir)
-    await writePackageAccess(dir, r, 'public')
+    await writePackageFields(dir, r, { publishConfig: { access: 'public' } })
     const written = await readFile(join(dir, 'package.json'), 'utf8')
     const parsed = JSON.parse(written) as Record<string, unknown>
     assert.deepStrictEqual((parsed['publishConfig'] as Record<string, unknown>)['access'], 'public')
     assert.ok(written.endsWith('\n'), 'trailing newline preserved')
-    // Check indent — the publishConfig key should be indented by 2 spaces
     assert.ok(written.includes('\n  "publishConfig"'), '2-space indent preserved')
   })
 
   test('preserves tab indent', async () => {
     await writeFile(join(dir, 'package.json'), '{\n\t"name": "bar"\n}\n')
     const r = await readPackage(dir)
-    await writePackageAccess(dir, r, 'restricted')
+    await writePackageFields(dir, r, { publishConfig: { access: 'restricted' } })
     const written = await readFile(join(dir, 'package.json'), 'utf8')
     assert.ok(written.includes('\n\t"publishConfig"'), 'tab indent preserved')
   })
@@ -80,7 +79,7 @@ describe('writePackageAccess', () => {
   test('preserves absence of trailing newline', async () => {
     await writeFile(join(dir, 'package.json'), '{\n  "name": "baz"\n}')
     const r = await readPackage(dir)
-    await writePackageAccess(dir, r, 'public')
+    await writePackageFields(dir, r, { publishConfig: { access: 'public' } })
     const written = await readFile(join(dir, 'package.json'), 'utf8')
     assert.ok(!written.endsWith('\n'), 'no trailing newline preserved')
   })
@@ -90,7 +89,7 @@ describe('writePackageAccess', () => {
       '{\n  "name": "foo",\n  "publishConfig": {\n    "registry": "https://example.com"\n  }\n}\n'
     await writeFile(join(dir, 'package.json'), original)
     const r = await readPackage(dir)
-    await writePackageAccess(dir, r, 'restricted')
+    await writePackageFields(dir, r, { publishConfig: { access: 'restricted' } })
     const written = await readFile(join(dir, 'package.json'), 'utf8')
     const parsed = JSON.parse(written) as { publishConfig: Record<string, unknown> }
     assert.strictEqual(parsed.publishConfig['access'], 'restricted')
@@ -101,9 +100,30 @@ describe('writePackageAccess', () => {
     const original = '{\n  "name": "foo",\n  "publishConfig": { "access": "public" }\n}\n'
     await writeFile(join(dir, 'package.json'), original)
     const r = await readPackage(dir)
-    await writePackageAccess(dir, r, 'restricted')
+    await writePackageFields(dir, r, { publishConfig: { access: 'restricted' } })
     const written = await readFile(join(dir, 'package.json'), 'utf8')
     const parsed = JSON.parse(written) as { publishConfig: Record<string, unknown> }
     assert.strictEqual(parsed.publishConfig['access'], 'restricted')
+  })
+
+  test('writes repository field', async () => {
+    const original = '{\n  "name": "foo"\n}\n'
+    await writeFile(join(dir, 'package.json'), original)
+    const r = await readPackage(dir)
+    await writePackageFields(dir, r, { repository: 'https://github.com/owner/repo' })
+    const written = await readFile(join(dir, 'package.json'), 'utf8')
+    const parsed = JSON.parse(written) as Record<string, unknown>
+    assert.strictEqual(parsed['repository'], 'https://github.com/owner/repo')
+  })
+
+  test('writes publishConfig.provenance and access together', async () => {
+    const original = '{\n  "name": "foo"\n}\n'
+    await writeFile(join(dir, 'package.json'), original)
+    const r = await readPackage(dir)
+    await writePackageFields(dir, r, { publishConfig: { access: 'public', provenance: true } })
+    const written = await readFile(join(dir, 'package.json'), 'utf8')
+    const parsed = JSON.parse(written) as { publishConfig: Record<string, unknown> }
+    assert.strictEqual(parsed.publishConfig['access'], 'public')
+    assert.strictEqual(parsed.publishConfig['provenance'], true)
   })
 })


### PR DESCRIPTION
- Automatically write `publishConfig.provenance: true` and `repository` URL to the source `package.json` during setup.
- Post-publish hints are now shown when using `--no-publish`.
- `--force` now also bypasses the "already published — nothing to do" early exit, allowing you to do a full setup but dry run or no-publish it.