### PR TITLE
fix: include user-agent in unsupported package manager error message

### DIFF
--- a/.changeset/unsupported-pm-user-agent-hint.md
+++ b/.changeset/unsupported-pm-user-agent-hint.md
@@ -1,0 +1,7 @@
+---
+'setup-trusted-publishing': patch
+---
+
+Include the raw `npm_config_user_agent` value in the unsupported package manager error message.
+
+This makes it easier to identify the exact user agent string when reporting support for a new package manager.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -178,9 +178,11 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
   )
 
   if (!noPublish && !dryRun && pmDetection.pm === null) {
+    const ua = env['npm_config_user_agent']
     err(
-      `Unsupported package manager: ${pmDetection.unsupported}. ` +
-        `Use --no-publish to prepare the stub tarball and publish it manually.`
+      `Unsupported package manager: ${pmDetection.unsupported}` +
+        (ua ? ` (user-agent: ${ua})` : '') +
+        `. Use --no-publish to prepare the stub tarball and publish it manually.`
     )
     return 1
   }


### PR DESCRIPTION
Makes it easier to identify the exact `npm_config_user_agent` string when reporting support for a new package manager.