### PR TITLE
fix: Bun compatibility (replace mkdtempDisposable)

### DIFF
--- a/.changeset/fix-bun-mkdtempdisposable.md
+++ b/.changeset/fix-bun-mkdtempdisposable.md
@@ -1,0 +1,5 @@
+---
+'setup-trusted-publishing': patch
+---
+
+Fix compatibility with Bun: `mkdtempDisposable` was added in Node.js v24 and is not yet available in Bun. Replaced with an inline implementation using `mkdtemp` + `rm`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { promises as fs } from 'node:fs'
-import { mkdtempDisposable } from 'node:fs/promises'
 import validate from 'validate-npm-package-name'
 import { readPackage, writePackageFields } from './packument.ts'
 import { resolveAccess, AccessConflictError } from './access.ts'
@@ -79,6 +78,17 @@ function logPostPublishHints(
   log(
     `hint: the repository URL in package.json is case-sensitive for provenance and trusted publishing,\n      verify it exactly matches your GitHub (or other host) URL`
   )
+}
+
+// mkdtempDisposable was added in Node.js v24 and is absent from Bun — roll our own.
+async function makeTempDir(prefix: string): Promise<{ path: string } & AsyncDisposable> {
+  const tmpPath = await fs.mkdtemp(prefix)
+  return {
+    path: tmpPath,
+    async [Symbol.asyncDispose]() {
+      await fs.rm(tmpPath, { recursive: true, force: true })
+    },
+  }
 }
 
 export default async function main(opts: MainOptions = {}): Promise<number> {
@@ -285,8 +295,7 @@ export default async function main(opts: MainOptions = {}): Promise<number> {
 
   const tarballName = `${name.replace(/^@/, '').replace(/\//g, '-')}-0.0.0.tgz`
 
-  // mkdtempDisposable returns { path, remove, [Symbol.asyncDispose] }
-  await using tempDir = await mkdtempDisposable(join(tmpdir(), 'setup-tp-'))
+  await using tempDir = await makeTempDir(join(tmpdir(), 'setup-tp-'))
   const tempPath: string = tempDir.path
 
   // Step 11: Write stub files


### PR DESCRIPTION
## Summary

- `mkdtempDisposable` was added in Node.js v24 and is not yet available in Bun
- Replaced with an inline implementation using `mkdtemp` + `rm` with `Symbol.asyncDispose`, so `await using` still works correctly
- Confirmed working in Bun v1.3.14 via Docker

## Test plan

- [x] All 82 existing tests pass
- [x] Verified manually with `docker run --rm -it -v "$PWD":/workspace -w /workspace oven/bun:latest sh` + `bunx setup-trusted-publishing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)